### PR TITLE
Fix typo in TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,8 +5,8 @@
 - HTTP servlet that loads static files into memory, in a reactive sense.
 - HTTP client
 - libtls coroutine
-  - server coroutine
-    - `vk_socket_peak()` for HelloClient header routing
+    - server coroutine
+      - `vk_socket_peek()` for HelloClient header routing
   - client coroutine (with mTLS support)
 - `vk_socket_open()` API
 - `struct vk_filemap` object, for file update events (`fstat()`, or get data from event) 


### PR DESCRIPTION
## Summary
- fix spelling of `vk_socket_peek()` in TODO.md

## Testing
- `make test` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_685d7947e6708333b8e841e274922cd1