### PR TITLE
Fix bugs in stack and fd table utilities

### DIFF
--- a/vk_fd_table.c
+++ b/vk_fd_table.c
@@ -126,15 +126,14 @@ void vk_fd_table_dump(struct vk_fd_table* fd_table_ptr)
 {
 	size_t i;
 
-	for (i = 0; i < fd_table_ptr->size; i++) {
-		struct vk_fd* fd_ptr;
-		for (i = 0; i < fd_table_ptr->size; i++) {
-			fd_ptr = vk_fd_table_get(fd_table_ptr, i);
-			if (fd_ptr != NULL && vk_fd_get_allocated(fd_ptr)) {
-				vk_fd_log("allocated");
-			}
-		}
-	}
+        for (i = 0; i < fd_table_ptr->size; i++) {
+                struct vk_fd* fd_ptr;
+
+                fd_ptr = vk_fd_table_get(fd_table_ptr, i);
+                if (fd_ptr != NULL && vk_fd_get_allocated(fd_ptr)) {
+                        vk_fd_log("allocated");
+                }
+        }
 }
 
 /*

--- a/vk_stack.c
+++ b/vk_stack.c
@@ -134,7 +134,8 @@ int vk_stack_push_stack(struct vk_stack* stack_ptr, struct vk_stack* new_stack_p
 		return -1;
 	}
 
-	vk_stack_init(stack_ptr, new_stack_ptr, nmemb * count);
+        /* initialize the new stack using the allocated memory */
+        vk_stack_init(new_stack_ptr, addr, nmemb * count);
 
 	return 0;
 }


### PR DESCRIPTION
## Summary
- correct initialization of new stack in `vk_stack_push_stack`
- fix logic in `vk_fd_table_dump` so each FD is checked exactly once

## Testing
- `gcc -c vk_stack.c -o /tmp/vk_stack.o`
- `gcc -c vk_fd_table.c -o /tmp/vk_fd_table.o` *(fails: `POLLRDHUP` undeclared)*
- `cmake ..` *(fails: could not find LibreSSL)*

------
https://chatgpt.com/codex/tasks/task_e_685d7779a7c883339e1cf73bbf40c2d1