### PR TITLE
docs: clarify coroutine architecture and I/O

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,42 @@ Key areas of the project include:
 - **Build systems**: Both BSD Make (invoked via `bmake`) and CMake are supported.
 
 Always ensure tests pass before committing changes.
+
+## Coroutines
+
+See [threads.md](threads.md) for an overview of the coroutine model. Coroutines
+are stackless and communicate via sockets, offering lockless, fully cooperative
+concurrency reminiscent of Go's goroutines or Erlang's processes.
+
+Coroutine functions share the signature `void name(struct vk_thread *that)`; any
+other arguments are copied by the caller into the top of `self` before entry
+using `vk_copy_arg`. `vk_begin()` allocates the coroutine's `self` state object
+on the micro-heap. Each `vk_*()` function, implemented as a macro emitting a
+state machine stage, may clear stack locals that are not stored in `self`.
+Local variables must not live across a `vk_*()` call unless preserved in `self`;
+otherwise the behavior is undefined.
+
+I/O automation is handled by `vk_*()` macros (e.g. `vk_readline()`). Regular
+functions may be called for non-I/O work, but they cannot perform I/O on their
+own because they are not coroutines.
+
+**Example**
+
+```c
+void example(struct vk_thread *that) {
+    int rc = 0; // stack local
+    struct {
+        int limit;       // argument copied via vk_copy_arg
+        int total;
+        char line[64];
+    } *self;
+    vk_begin();                       // allocates `self`
+
+    vk_readline(rc, self->line, sizeof(self->line) - 1);
+    self->total += rc;                // persist across `vk_*()` calls
+
+    vk_yield(VK_PROC_YIELD);          // `rc` is undefined after this
+
+    vk_end();                         // frees `self`
+}
+```


### PR DESCRIPTION
## Summary
- describe coroutines as stackless, socket-based, and fully cooperative
- clarify that regular functions may be called for non-I/O work and I/O must use `vk_*()` macros

## Testing
- `./debug.sh bmake test`


------
https://chatgpt.com/codex/tasks/task_e_68b12b0417508333868f72681f1a3446