### PR TITLE
Handle redis response allocation failures

### DIFF
--- a/vk_redis.c
+++ b/vk_redis.c
@@ -107,16 +107,24 @@ void redis_response(struct vk_thread* that)
                         vk_write_literal("-ERR unknown command\r\n");
                         vk_flush();
                 }
-	} while (!vk_nodata());
+        } while (!vk_nodata());
 
+        vk_flush();
+        vk_tx_close();
+
+        errno = 0;
         vk_finally();
-        if (self->db) {
+        if (self && self->db) {
                 sqlite3_close(self->db);
         }
         if (errno) {
                 vk_perror("redis_response");
+                vk_flush();
+                vk_tx_close();
         }
-        vk_free();
+        if (self) {
+                vk_free();
+        }
         vk_end();
 }
 

--- a/vk_test_redis_cli.c
+++ b/vk_test_redis_cli.c
@@ -3,5 +3,5 @@
 
 int main(int argc, char* argv[])
 {
-        return vk_main_init(redis_request, NULL, 0, 25, 0, 1);
+        return vk_main_init(redis_request, NULL, 0, 40, 0, 1);
 }


### PR DESCRIPTION
## Summary
- avoid dereferencing an uninitialized redis response state by guarding the cleanup
- allocate more pages for the redis CLI test to satisfy wider struct layout
- flush and close the redis responder so only it physically closes the connection

## Testing
- `./debug.sh bmake test`


------
https://chatgpt.com/codex/tasks/task_e_68b15898bddc833395b47d302e28392c