### PR TITLE
Fix Redis QUIT handling in client

### DIFF
--- a/vk_redis.h
+++ b/vk_redis.h
@@ -8,6 +8,7 @@
 
 struct redis_query {
         int argc;
+        int close;
         char argv[REDIS_MAX_ARGS][REDIS_MAX_BULK];
 };
 


### PR DESCRIPTION
## Summary
- track close state in redis_query struct
- exit request loop when QUIT sets close flag
- terminate response loop on close and send final OK

## Testing
- `./debug.sh bmake test`
- `cat vk_test_redis.in.txt | ./vk_test_redis_cli 2>/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68b1cf258d20833389ccfcf25203a073