### PR TITLE
Handle Redis SHUTDOWN via kernel shutdown

### DIFF
--- a/vk_redis.h
+++ b/vk_redis.h
@@ -9,6 +9,7 @@
 struct redis_query {
         int argc;
         int close;
+        int shutdown;
         char argv[REDIS_MAX_ARGS][REDIS_MAX_BULK];
 };
 

--- a/vk_service.c
+++ b/vk_service.c
@@ -30,6 +30,9 @@ void vk_service_listener(struct vk_thread* that)
 	}
 
 	for (;;) {
+		if (vk_kern_get_shutdown_requested(self->server_ptr->kern_ptr)) {
+			break;
+		}
 		vk_accept(self->accepted_fd, self->accepted_ptr);
 		vk_dbgf("vk_accept() from client %s:%s as FD %i\n", vk_accepted_get_address_str(self->accepted_ptr),
 			vk_accepted_get_port_str(self->accepted_ptr), self->accepted_fd);


### PR DESCRIPTION
## Summary
- avoid closing stdin in the kernel loop and rely on shutdown flag
- break service listener when shutdown is requested
- let Redis SHUTDOWN propagate to the kernel by flushing and clearing errno before invoking the response handler
- set shutdown and close flags during command parsing to avoid duplicate `strcasecmp` checks

## Testing
- `./debug.sh bmake vk_test_redis_service vk_test_redis_client_cli`
- `timeout 15 ./debug.sh bmake test 2>&1 | head -n 1000` (produced extensive debug output before terminating)


------
https://chatgpt.com/codex/tasks/task_e_68b3325e8bb88333b3af1b5955062ec4